### PR TITLE
Use turnpike's "Associate" type in GET events

### DIFF
--- a/db.go
+++ b/db.go
@@ -171,22 +171,6 @@ func (db *DB) GetEvents(limit int, offset int) ([]map[string]interface{}, error)
 	return events, nil
 }
 
-// CountAccountsEvents returns the number of records found in the accounts_events
-// table with the given account ID.
-func (db *DB) CountAccountsEvents(accountID string) (int, error) {
-	stmt, err := db.preparedStatement(`SELECT COUNT(*) FROM accounts_events WHERE account_id = $1;`)
-	if err != nil {
-		return -1, err
-	}
-
-	var count int
-	err = stmt.QueryRow(accountID).Scan(&count)
-	if err != nil {
-		return -1, err
-	}
-	return count, nil
-}
-
 // Migrate inspects the current active migration version and runs all necessary
 // steps to migrate all the way up. If reset is true, everything is deleted in
 // the database before applying migrations.

--- a/db_test.go
+++ b/db_test.go
@@ -47,57 +47,6 @@ func TestDBCount(t *testing.T) {
 	}
 }
 
-func TestCountAccountsEvents(t *testing.T) {
-	tests := []struct {
-		desc  string
-		input struct{ query, accountID, queryParameter string }
-		want  int
-	}{
-		{
-			desc: "account ID present",
-			input: struct {
-				query          string
-				accountID      string
-				queryParameter string
-			}{`INSERT INTO accounts_events (account_id) VALUES ('%s');`, "1", "1"},
-			want: 1,
-		},
-		{
-			desc: "account ID absent",
-			input: struct {
-				query          string
-				accountID      string
-				queryParameter string
-			}{`INSERT INTO accounts_events (account_id) VALUES ('%s');`, "1", "2"},
-			want: 0,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.desc, func(t *testing.T) {
-			db, err := Open("sqlite3", "file::memory:?cache=shared")
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer db.Close()
-			if err := db.Migrate(false); err != nil {
-				t.Fatal(err)
-			}
-			if err := db.seedData([]byte(fmt.Sprintf(test.input.query, test.input.accountID))); err != nil {
-				t.Fatal(err)
-			}
-
-			got, err := db.CountAccountsEvents(test.input.queryParameter)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if got != test.want {
-				t.Errorf("%+v != %+v", got, test.want)
-			}
-		})
-	}
-}
-
 func TestDBInsertEvents(t *testing.T) {
 	type record struct {
 		phase       string

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible
 	github.com/peterbourgon/ff/v3 v3.0.0
 	github.com/prometheus/client_golang v1.5.1
-	github.com/redhatinsights/platform-go-middlewares v0.7.0
+	github.com/redhatinsights/platform-go-middlewares v0.7.1-0.20201009171810-b73c54b47a2d
 	github.com/segmentio/kafka-go v0.3.7
 	github.com/sirupsen/logrus v1.5.0
 	github.com/slok/go-http-metrics v0.6.1

--- a/go.sum
+++ b/go.sum
@@ -325,6 +325,8 @@ github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+Gx
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/redhatinsights/platform-go-middlewares v0.7.0 h1:1prVr6XxYHSKThfblJr3kaLecD/6s4xaQ9zZ+BKhHJM=
 github.com/redhatinsights/platform-go-middlewares v0.7.0/go.mod h1:g//UN9p5sxgIoZfRyyiRy+rAw1/GMqkZ4hWUFcEC71A=
+github.com/redhatinsights/platform-go-middlewares v0.7.1-0.20201009171810-b73c54b47a2d h1:uxm5aXj3SYrAu3beL0+8VLYHA7RPhvoX47NQgBxVPCA=
+github.com/redhatinsights/platform-go-middlewares v0.7.1-0.20201009171810-b73c54b47a2d/go.mod h1:g//UN9p5sxgIoZfRyyiRy+rAw1/GMqkZ4hWUFcEC71A=
 github.com/remyoudompheng/bigfft v0.0.0-20190728182440-6a916e37a237/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=

--- a/migrations/20201013131514_drop_accounts_events_table.down.sql
+++ b/migrations/20201013131514_drop_accounts_events_table.down.sql
@@ -1,0 +1,4 @@
+CREATE TABLE accounts_events (
+    account_id VARCHAR(256),
+    PRIMARY KEY(account_id)
+)

--- a/migrations/20201013131514_drop_accounts_events_table.up.sql
+++ b/migrations/20201013131514_drop_accounts_events_table.up.sql
@@ -1,0 +1,1 @@
+DROP TABLE accounts_events;

--- a/routes.go
+++ b/routes.go
@@ -218,12 +218,7 @@ func (s *Server) handleEvent() http.HandlerFunc {
 			w.WriteHeader(http.StatusCreated)
 		case http.MethodGet:
 			id := identity.Get(r.Context())
-			count, err := s.db.CountAccountsEvents(id.Identity.AccountNumber)
-			if err != nil {
-				formatJSONError(w, http.StatusInternalServerError, err.Error())
-				return
-			}
-			if count < 1 {
+			if id.Identity.Type != "Associate" {
 				formatJSONError(w, http.StatusUnauthorized, "")
 				return
 			}

--- a/routes_test.go
+++ b/routes_test.go
@@ -77,7 +77,7 @@ func TestRouter(t *testing.T) {
 				url:    "/api/module-update-router/v1/event?limit=1",
 				body:   ``,
 				headers: map[string]string{
-					"X-Rh-Identity": base64.StdEncoding.EncodeToString([]byte(`{ "identity": { "account_number": "540155", "type": "User", "internal": { "org_id": "1979710" } } }`)),
+					"X-Rh-Identity": base64.StdEncoding.EncodeToString([]byte(`{ "identity": { "account_number": "540155", "type": "Associate", "internal": { "org_id": "1979710" } } }`)),
 				},
 			},
 			want: response{
@@ -92,7 +92,7 @@ func TestRouter(t *testing.T) {
 				url:    "/api/module-update-router/v1/event",
 				body:   ``,
 				headers: map[string]string{
-					"X-Rh-Identity": base64.StdEncoding.EncodeToString([]byte(`{ "identity": { "account_number": "540155", "type": "User", "internal": { "org_id": "1979710" } } }`)),
+					"X-Rh-Identity": base64.StdEncoding.EncodeToString([]byte(`{ "identity": { "account_number": "540155", "type": "Associate", "internal": { "org_id": "1979710" } } }`)),
 				},
 			},
 			want: response{
@@ -107,7 +107,7 @@ func TestRouter(t *testing.T) {
 				url:    "/api/module-update-router/v1/event?offset=1&limit=1",
 				body:   ``,
 				headers: map[string]string{
-					"X-Rh-Identity": base64.StdEncoding.EncodeToString([]byte(`{ "identity": { "account_number": "540155", "type": "User", "internal": { "org_id": "1979710" } } }`)),
+					"X-Rh-Identity": base64.StdEncoding.EncodeToString([]byte(`{ "identity": { "account_number": "540155", "type": "Associate", "internal": { "org_id": "1979710" } } }`)),
 				},
 			},
 			want: response{

--- a/routes_test.go
+++ b/routes_test.go
@@ -129,7 +129,6 @@ func TestRouter(t *testing.T) {
 				t.Fatal(err)
 			}
 			db.seedData([]byte(`INSERT INTO accounts_modules (account_id, module_name) VALUES ('540155', 'insights-core');`))
-			db.seedData([]byte(`INSERT INTO accounts_events (account_id) VALUES ('540155');`))
 			db.seedData([]byte(`INSERT INTO events (event_id, phase, started_at, exit, exception, ended_at, machine_id, core_version, core_path)
 			VALUES ("af3b8e13-6b65-45d8-8310-a45e0821bd62", "pre_update", "2020-06-19T11:18:03Z", 1, NULL, "2020-07-15T17:17:37Z", "a9ab0a44-1241-43ae-9c02-1850acf0c36c", "3.0.156", "/etc/insights-client/rpm.egg");`))
 			db.seedData([]byte(`INSERT INTO events (event_id, phase, started_at, exit, exception, ended_at, machine_id, core_version, core_path)


### PR DESCRIPTION
Since `/events` is meant for internal consumption only, we can deny access unless the `X-Rh-Identity` "type" value is `"Associate"`.