### PR TITLE
Fix sample `go install` command

### DIFF
--- a/identity/cmd/xrhidgen/README.md
+++ b/identity/cmd/xrhidgen/README.md
@@ -4,7 +4,7 @@ requests to console.redhat.com services.
 # Installation
 
 ```
-go install github.com/RedHatInsights/module-update-router/identity/cmd/xrhidgen@latest
+go install github.com/redhatinsights/module-update-router/identity/cmd/xrhidgen@latest
 ```
 
 # Usage


### PR DESCRIPTION
Sample output:

    $ go install github.com/RedHatInsights/module-update-router/identity/cmd/xrhidgen@latest

    go: downloading github.com/RedHatInsights/module-update-router v0.0.0-20220506161415-c79dc72262c0
    go: github.com/RedHatInsights/module-update-router/identity/cmd/xrhidgen@latest: github.com/RedHatInsights/module-update-router@v0.0.0-20220506161415-c79dc72262c0: parsing go.mod:
            module declares its path as: github.com/redhatinsights/module-update-router
                    but was required as: github.com/RedHatInsights/module-update-router
    $ go install github.com/redhatinsights/module-update-router/identity/cmd/xrhidgen@latest
    go: downloading github.com/redhatinsights/module-update-router v0.0.0-20220506161415-c79dc72262c0
    (snip!)