### PR TITLE
Silently drop POST /event requests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/redhatinsights/app-common-go v1.6.3
 	github.com/redhatinsights/platform-go-middlewares v0.10.0
 	github.com/segmentio/kafka-go v0.3.7
-	github.com/sgreben/flagvar v1.10.1 // indirect
+	github.com/sgreben/flagvar v1.10.1
 	github.com/sirupsen/logrus v1.9.0
 	github.com/slok/go-http-metrics v0.6.1
 )

--- a/metrics.go
+++ b/metrics.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"time"
-
 	p "github.com/prometheus/client_golang/prometheus"
 	pa "github.com/prometheus/client_golang/prometheus/promauto"
 )
@@ -12,27 +10,8 @@ var (
 		Name: "module_update_router_requests",
 		Help: "Total number of GETs to router",
 	}, []string{"endpoint"})
-
-	events = pa.NewCounterVec(p.CounterOpts{
-		Name: "module_update_router_events",
-		Help: "Total number of events recorded",
-	}, []string{"core_version"})
-
-	clientElapsed = pa.NewHistogramVec(p.HistogramOpts{
-		Name: "module_update_router_client_seconds",
-		Help: "The number of seconds a client request takes",
-	}, []string{"phase"})
 )
 
 func incRequests(endpoint string) {
 	requests.With(p.Labels{"endpoint": endpoint}).Inc()
-}
-
-func incEvents(coreVersion string) {
-	events.With(p.Labels{"core_version": coreVersion}).Inc()
-}
-
-func observeClientElapsed(phase string, startTime time.Time, endTime time.Time) {
-	duration := endTime.Sub(startTime)
-	clientElapsed.With(p.Labels{"phase": phase}).Observe(duration.Seconds())
 }

--- a/routes.go
+++ b/routes.go
@@ -1,10 +1,8 @@
 package main
 
 import (
-	"database/sql"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -138,96 +136,9 @@ func (s *Server) handleChannel() http.HandlerFunc {
 
 // handleEvent creates an http.HandlerFunc for the API endpoint /event.
 func (s *Server) handleEvent() http.HandlerFunc {
-	type requestBody struct {
-		Phase       *string    `json:"phase"`
-		StartedAt   *time.Time `json:"started_at"`
-		Exit        *int       `json:"exit"`
-		Exception   *string    `json:"exception"`
-		EndedAt     *time.Time `json:"ended_at"`
-		MachineID   *string    `json:"machine_id"`
-		CoreVersion *string    `json:"core_version"`
-		CorePath    *string    `json:"core_path"`
-	}
-	type event struct {
-		Phase       string
-		StartedAt   time.Time
-		Exit        int
-		Exception   sql.NullString
-		EndedAt     time.Time
-		MachineID   string
-		CoreVersion string
-		CorePath    string
-	}
 	return func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodPost:
-			data, err := io.ReadAll(r.Body)
-			if err != nil {
-				formatJSONError(w, http.StatusBadRequest, err.Error())
-				return
-			}
-			defer r.Body.Close()
-
-			var body requestBody
-			if err := json.Unmarshal(data, &body); err != nil {
-				formatJSONError(w, http.StatusBadRequest, err.Error())
-				return
-			}
-
-			// Check required fields for presence of a value. Each struct member of
-			// body is compared to the nil value, and an error is returned if a value
-			// is found to be nil.
-			for p, v := range map[string]interface{}{
-				"phase":        body.Phase,
-				"started_at":   body.StartedAt,
-				"exit":         body.Exit,
-				"ended_at":     body.EndedAt,
-				"machine_id":   body.MachineID,
-				"core_version": body.CoreVersion,
-				"core_path":    body.CorePath,
-			} {
-				switch t := v.(type) {
-				case *string:
-					if v.(*string) == nil {
-						formatJSONError(w, http.StatusBadRequest, fmt.Sprintf(`missing required %T field: '%v'`, t, p))
-						return
-					}
-				case *int:
-					if v.(*int) == nil {
-						formatJSONError(w, http.StatusBadRequest, fmt.Sprintf(`missing required %T field: '%v'`, t, p))
-						return
-					}
-				case *time.Time:
-					if v.(*time.Time) == nil {
-						formatJSONError(w, http.StatusBadRequest, fmt.Sprintf(`missing required %T field: '%v'`, t, p))
-						return
-					}
-				default:
-					formatJSONError(w, http.StatusBadRequest, fmt.Sprintf(`unsupported type: '%T'`, t))
-					return
-				}
-			}
-
-			e := event{
-				Phase:       *body.Phase,
-				StartedAt:   *body.StartedAt,
-				Exit:        *body.Exit,
-				Exception:   NewNullString(body.Exception),
-				EndedAt:     *body.EndedAt,
-				MachineID:   *body.MachineID,
-				CoreVersion: *body.CoreVersion,
-				CorePath:    *body.CorePath,
-			}
-
-			if err := s.db.InsertEvents(e.Phase, e.StartedAt, e.Exit, e.Exception, e.EndedAt, e.MachineID, e.CoreVersion, e.CorePath); err != nil {
-				formatJSONError(w, http.StatusInternalServerError, err.Error())
-				return
-			}
-			if s.events != nil {
-				*s.events <- data
-			}
-			incEvents(e.CoreVersion)
-			observeClientElapsed(e.Phase, e.StartedAt, e.EndedAt)
 			w.WriteHeader(http.StatusCreated)
 		case http.MethodGet:
 			id, err := identity.GetIdentity(r)

--- a/routes_test.go
+++ b/routes_test.go
@@ -61,16 +61,6 @@ func TestRouter(t *testing.T) {
 			want:  response{http.StatusCreated, ""},
 		},
 		{
-			desc:  "POST /event - want BAD REQUEST - exit is null",
-			input: request{http.MethodPost, "/api/module-update-router/v1/event", `{"phase": "pre_update", "started_at": "2020-06-19T11:18:03-04:00", "exit": null, "exception": "OSPermissionError", "ended_at": "2020-06-19T11:19:03-04:00", "machine_id": "60654767-dfba-47af-8bca-cb2d1d01d9a6", "core_version": "3.0.156", "core_path": "/etc/rpm/insights.egg"}`, map[string]string{"X-Rh-Identity": base64.StdEncoding.EncodeToString([]byte(`{ "identity": { "org_id": "1979710", "account_number": "540155", "type": "User", "internal": { "org_id": "1979710" } } }`))}},
-			want:  response{http.StatusBadRequest, `{"errors":[{"status":"Bad Request","title":"missing required *int field: 'exit'"}]}`},
-		},
-		{
-			desc:  "POST /event - want BAD REQUEST - exit is omitted",
-			input: request{http.MethodPost, "/api/module-update-router/v1/event", `{"phase": "pre_update", "started_at": "2020-06-19T11:18:03-04:00", "exception": "OSPermissionError", "ended_at": "2020-06-19T11:19:03-04:00", "machine_id": "60654767-dfba-47af-8bca-cb2d1d01d9a6", "core_version": "3.0.156", "core_path": "/etc/rpm/insights.egg"}`, map[string]string{"X-Rh-Identity": base64.StdEncoding.EncodeToString([]byte(`{ "identity": { "org_id": "1979710", "account_number": "540155", "type": "User", "internal": { "org_id": "1979710" } } }`))}},
-			want:  response{http.StatusBadRequest, `{"errors":[{"status":"Bad Request","title":"missing required *int field: 'exit'"}]}`},
-		},
-		{
 			desc: "GET /event - limit 1",
 			input: request{
 				method: http.MethodGet,


### PR DESCRIPTION
Since module-update-router is no longer accepting "event" data, don't handle the HTTP requests sent to /events with a method of POST. The request is still responded to with an HTTP 201 to maintain API compatibility, but the request is ignored.