### PR TITLE
refactor: drop migration init container

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -2,8 +2,7 @@
 
 ```
 podman run -it -d -e POSTGRES_PASSWORD=postgres postgres:latest
-go run ./ -migrate -seed-path seed.sql -db-driver pgx
-go run ./ -path-prefix /api -app-name module-update-router -db-driver pgx -db-pass postgres -log-level debug
+go run ./ -path-prefix /api -app-name module-update-router -db-driver pgx -db-pass postgres -log-level debug -seed-path seed.sql
 ```
 
 # Send HTTP requests

--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -22,8 +22,6 @@ objects:
               enabled: true
           podSpec:
             image: ${IMAGE}:${IMAGE_TAG}
-            args:
-              - "http-api"
             env:
               - name: APP_NAME
                 value: ${APP_NAME}
@@ -37,6 +35,8 @@ objects:
                 value: ${METRICS_TOPIC}
               - name: PATH_PREFIX
                 value: ${{PATH_PREFIX}}
+              - name: SEED_PATH
+                value: ${SEED_PATH}
             livenessProbe:
               httpGet:
                 path: /ping
@@ -54,13 +54,6 @@ objects:
             volumeMounts:
               - name: accounts-modules
                 mountPath: /seed
-            initContainers:
-              - name: migrate
-                image: ${IMAGE}:${IMAGE_TAG}
-                args:
-                  - "migrate"
-                  - "-seed-path=/seed/seed.sql"
-                inheritEnv: true
   - apiVersion: v1
     kind: Secret
     metadata:
@@ -92,3 +85,5 @@ parameters:
     value: "/api,/r/insights/platform"
   - name: WEB_PORT
     value: "8000"
+  - name: SEED_PATH
+    value: "/seed/seed.sql"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -81,6 +81,15 @@ func FlagSet(name string, errorHandling flag.ErrorHandling) *flag.FlagSet {
 	fs.StringVar(&DefaultConfig.DBUser, "db-user", DefaultConfig.DBUser, "database username")
 	fs.Var(&DefaultConfig.LogFormat, "log-format", fmt.Sprintf("set logging format (%v)", DefaultConfig.LogFormat.Help()))
 	fs.StringVar(&DefaultConfig.LogLevel, "log-level", DefaultConfig.LogLevel, "logging level")
+	fs.Var(&DefaultConfig.SeedPath, "seed-path", "path to the SQL seed file")
+	fs.BoolVar(&DefaultConfig.Reset, "reset", DefaultConfig.Reset, "drop all tables before running migrations")
+	fs.StringVar(&DefaultConfig.Addr, "addr", DefaultConfig.Addr, "app listen address")
+	fs.StringVar(&DefaultConfig.APIVersion, "api-version", DefaultConfig.APIVersion, "version to use in the URL path")
+	fs.StringVar(&DefaultConfig.AppName, "app-name", DefaultConfig.AppName, "name component for the API prefix")
+	fs.IntVar(&DefaultConfig.EventBuffer, "event-buffer", DefaultConfig.EventBuffer, "the size of the event channel buffer")
+	fs.StringVar(&DefaultConfig.MAddr, "maddr", DefaultConfig.MAddr, "metrics listen address")
+	fs.StringVar(&DefaultConfig.MetricsTopic, "metrics-topic", DefaultConfig.MetricsTopic, "topic on which to place metrics data")
+	fs.StringVar(&DefaultConfig.PathPrefix, "path-prefix", DefaultConfig.PathPrefix, "API path prefix")
 
 	return fs
 }


### PR DESCRIPTION
Since the database is truncated and refreshed every time
module-update-router is started, remove the 'migrate' subcommand and
init container; let the migration run every time the program is started.
Consequently, the 'http-api' subcommand is also removed.