### PR TITLE
chore: use ubi9 as base in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/go-toolset:latest as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:latest as builder
 
 USER root
 


### PR DESCRIPTION
- RHINENG-12562, RHINENG-12558