### PR TITLE
Revert "chore: use ubi9 as base in Dockerfile"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:latest as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:latest as builder
 
 USER root
 


### PR DESCRIPTION
- Reverts RedHatInsights/module-update-router#76
- see RHINENG-13885
