### PR TITLE
feat(RHINENG-25399): add non-authenticated openapi.json route

### DIFF
--- a/routes.go
+++ b/routes.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	_ "embed"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -20,6 +21,9 @@ import (
 
 	request "github.com/redhatinsights/platform-go-middlewares/v2/request_id"
 )
+
+//go:embed openapi.json
+var openAPISpec []byte
 
 var r metrics.Recorder = httpmetrics.NewRecorder(httpmetrics.Config{})
 
@@ -63,6 +67,7 @@ func (s *Server) Close() error {
 func (s *Server) routes(prefixes ...string) {
 	s.mux.HandleFunc("/ping", s.handlePing())
 	for _, prefix := range prefixes {
+		s.mux.HandleFunc(path.Join(prefix, "openapi.json"), s.handleOpenAPI())
 		s.mux.HandleFunc(prefix+"/", s.metrics(s.requestID(s.log(s.auth(s.handleAPI(prefix))))))
 	}
 }
@@ -72,6 +77,16 @@ func (s *Server) routes(prefixes ...string) {
 func (s *Server) handlePing() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if _, err := w.Write([]byte(`OK`)); err != nil {
+			log.Errorf("cannot write HTTP response: %v", err)
+		}
+	}
+}
+
+// handleOpenAPI creates an http.HandlerFunc that serves the openapi.json spec.
+func (s *Server) handleOpenAPI() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write(openAPISpec); err != nil {
 			log.Errorf("cannot write HTTP response: %v", err)
 		}
 	}

--- a/routes_test.go
+++ b/routes_test.go
@@ -31,6 +31,11 @@ func TestRouter(t *testing.T) {
 			want:  response{http.StatusOK, "OK"},
 		},
 		{
+			desc:  "GET /openapi.json - want openapi spec",
+			input: request{http.MethodGet, "/api/module-update-router/v1/openapi.json", "", nil},
+			want:  response{http.StatusOK, string(openAPISpec)},
+		},
+		{
 			desc:  "GET /channel - want /testing",
 			input: request{http.MethodGet, "/api/module-update-router/v1/channel?module=insights-core", "", map[string]string{"X-Rh-Identity": base64.StdEncoding.EncodeToString([]byte(`{ "identity": { "org_id": "1979710", "account_number": "540155", "type": "User", "internal": { "org_id": "1979710" } } }`))}},
 			want:  response{http.StatusOK, `{"url":"/testing"}`},


### PR DESCRIPTION
## Summary by Sourcery

Expose an unauthenticated HTTP endpoint to serve the embedded OpenAPI specification for the API.

New Features:
- Add an embedded openapi.json specification to the server binary and expose it via an HTTP route under each API prefix.

Tests:
- Extend router tests to cover the new openapi.json endpoint and validate it returns the embedded spec.